### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/doc/typed-stack.scrbl
+++ b/doc/typed-stack.scrbl
@@ -3,7 +3,7 @@
 @(require (for-label typed/racket/base
                      "../main.rkt"))
 
-@title{@bold{Typed-Stack}: A Typed Racket stack library}
+@title{Typed-Stack: A Typed Racket stack library}
 @author{Lehi Toskin}
 
 @defmodule[typed-stack]{


### PR DESCRIPTION
For visual consistency with other packages within the docs